### PR TITLE
Add an option to config casbin model from application code

### DIFF
--- a/CasbinModel.cs
+++ b/CasbinModel.cs
@@ -1,11 +1,12 @@
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
 
 namespace Casbin.NET.Adapter.EFCore
 {
-    public class CasbinDbContext : DbContext
+    public partial class CasbinDbContext : DbContext
     {
-        public DbSet<CasbinRule> CasbinRule { get; set; }
+        public virtual DbSet<CasbinRule> CasbinRule { get; set; }
+
+        private readonly IEntityTypeConfiguration<CasbinRule> _casbinModelConfig;
 
         public CasbinDbContext()
         {
@@ -15,9 +16,22 @@ namespace Casbin.NET.Adapter.EFCore
         {
         }
 
+        public CasbinDbContext(DbContextOptions<CasbinDbContext> options, IEntityTypeConfiguration<CasbinRule> casbinModelConfig) : base(options)
+        {
+            _casbinModelConfig = casbinModelConfig;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            if (_casbinModelConfig != null)
+            {
+                modelBuilder.ApplyConfiguration(_casbinModelConfig);
+            }
+        }
+
     }
 
-    public class CasbinRule
+    public partial class CasbinRule
     {
         public int Id { get; set; }
         public string PType { get; set; }

--- a/EFCore-Adapter.csproj
+++ b/EFCore-Adapter.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Casbin.NET.Adapter.EFCore</RootNamespace>
     <PackageId>Casbin.NET.Adapter.EFCore</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
first create a class that inherit IEntityTypeConfiguration<CasbinRule> and then inject it
and `CasbinDbContext` will know how to configure CasbinRule Model
This feature is useful when you have different names of policy tables, like:
`CasbinRule`, `casbin_rules`...