### PR TITLE
fix RemoveFilteredPolicy only removing single entry instead of all

### DIFF
--- a/EFCore-Adapter.UnitTest/AdapterTest.cs
+++ b/EFCore-Adapter.UnitTest/AdapterTest.cs
@@ -3,6 +3,7 @@ using Xunit;
 using Casbin.NET.Adapter.EFCore;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Linq;
 
 namespace EFCore_Adapter.Test
 {
@@ -78,6 +79,7 @@ namespace EFCore_Adapter.Test
                 AsList("data2_admin", "data2", "read"),
                 AsList("data2_admin", "data2", "write")
             ));
+            Assert.True(_context.CasbinRule.Count() == 5);
 
             e.AddPolicy("alice", "data1", "write");
             TestGetPolicy(e, AsList(
@@ -87,6 +89,7 @@ namespace EFCore_Adapter.Test
                 AsList("data2_admin", "data2", "write"),
                 AsList("alice", "data1", "write")
             ));
+            Assert.True(_context.CasbinRule.Count() == 6);
 
             e.RemovePolicy("alice", "data1", "write");
             TestGetPolicy(e, AsList(
@@ -95,13 +98,14 @@ namespace EFCore_Adapter.Test
                 AsList("data2_admin", "data2", "read"),
                 AsList("data2_admin", "data2", "write")
             ));
+            Assert.True(_context.CasbinRule.Count() == 5);
 
             e.RemoveFilteredPolicy(0, "data2_admin");
             TestGetPolicy(e, AsList(
                 AsList("alice", "data1", "read"),
                 AsList("bob", "data2", "write")
             ));
+            Assert.True(_context.CasbinRule.Count() == 3);
         }
-
     }
 }

--- a/EFCore-Adapter/CasbinDbAdapter.cs
+++ b/EFCore-Adapter/CasbinDbAdapter.cs
@@ -61,20 +61,39 @@ namespace Casbin.NET.Adapter.EFCore
             {
                 line.V5 = fieldValues[5 - fieldIndex];
             }
-            var dbRow = _context.CasbinRule.Where(p => p.PType == line.PType)
-               .Where(p => p.V0 == line.V0)
-               .Where(p => p.V1 == line.V1)
-               .Where(p => p.V2 == line.V2)
-               .Where(p => p.V3 == line.V3)
-               .Where(p => p.V4 == line.V4)
-               .Where(p => p.V5 == line.V5)
-               .FirstOrDefault();
-       
-            if (dbRow != null)
+
+            var query = _context.CasbinRule.Where(p => p.PType == line.PType);
+            if (!string.IsNullOrEmpty(line.V0))
+            {
+                query = query.Where(p => p.V0 == line.V0);
+            }
+            if (!string.IsNullOrEmpty(line.V1))
+            {
+                query = query.Where(p => p.V1 == line.V1);
+            }
+            if (!string.IsNullOrEmpty(line.V2))
+            {
+                query = query.Where(p => p.V2 == line.V2);
+            }
+            if (!string.IsNullOrEmpty(line.V3))
+            {
+                query = query.Where(p => p.V3 == line.V3);
+            }
+            if (!string.IsNullOrEmpty(line.V4))
+            {
+                query = query.Where(p => p.V4 == line.V4);
+            }
+            if (!string.IsNullOrEmpty(line.V5))
+            {
+                query = query.Where(p => p.V5 == line.V5);
+            }
+
+            foreach (var dbRow in query)
             {
                 _context.Entry(dbRow).State = EntityState.Deleted;
-                _context.SaveChanges();
             }
+
+            _context.SaveChanges();
         }
 
         public void SavePolicy(Model model)


### PR DESCRIPTION
RemoveFilteredPolicy didn't remove multiple entries (or any at all, depending on fields).
I added a check for item count in the context (don't have a lot of time, sorry), the test should only compare data in the context, as testing the external library is kinda pointless.