### PR TITLE
 .NET Core and EFCore 3.1 Updated & IAdapter Bug fixed 

### DIFF
--- a/EFCore-Adapter.UnitTest/EFCore-Adapter.UnitTest.csproj
+++ b/EFCore-Adapter.UnitTest/EFCore-Adapter.UnitTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -8,10 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/EFCore-Adapter.sln
+++ b/EFCore-Adapter.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29920.165
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore-Adapter", "EFCore-Adapter\EFCore-Adapter.csproj", "{A4A027E0-A0FA-40A9-A558-D6C89CB832E7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore-Adapter", "EFCore-Adapter\EFCore-Adapter.csproj", "{A4A027E0-A0FA-40A9-A558-D6C89CB832E7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore-Adapter.UnitTest", "EFCore-Adapter.UnitTest\EFCore-Adapter.UnitTest.csproj", "{0687B869-B179-4C4F-8419-B7D9B7C2DB5C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore-Adapter.UnitTest", "EFCore-Adapter.UnitTest\EFCore-Adapter.UnitTest.csproj", "{0687B869-B179-4C4F-8419-B7D9B7C2DB5C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +15,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A4A027E0-A0FA-40A9-A558-D6C89CB832E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -44,5 +41,11 @@ Global
 		{0687B869-B179-4C4F-8419-B7D9B7C2DB5C}.Release|x64.Build.0 = Release|Any CPU
 		{0687B869-B179-4C4F-8419-B7D9B7C2DB5C}.Release|x86.ActiveCfg = Release|Any CPU
 		{0687B869-B179-4C4F-8419-B7D9B7C2DB5C}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5781F5F2-3BA0-4FDA-BDEF-246089CA80B9}
 	EndGlobalSection
 EndGlobal

--- a/EFCore-Adapter/CasbinDbAdapter.cs
+++ b/EFCore-Adapter/CasbinDbAdapter.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Linq;
 using System;
 using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
 
 namespace Casbin.NET.Adapter.EFCore
 {
@@ -197,6 +198,21 @@ namespace Casbin.NET.Adapter.EFCore
             }
 
             return line;
+        }
+
+        public Task LoadPolicyAsync(Model model)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SavePolicyAsync(Model model)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task AddPolicyAsync(string sec, string ptype, IList<string> rule)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/EFCore-Adapter/EFCore-Adapter.csproj
+++ b/EFCore-Adapter/EFCore-Adapter.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Casbin.NET.Adapter.EFCore</RootNamespace>
     <PackageId>Casbin.NET.Adapter.EFCore</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore-Adapter/EFCore-Adapter.csproj
+++ b/EFCore-Adapter/EFCore-Adapter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,8 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Casbin.NET" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
+    <PackageReference Include="Casbin.NET" Version="1.2.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET Core and EFCore 3.1 has been updated with stable version  `Microsoft.EntityFrameworkCore.Design Version="3.1.3".`

Also IAdapter bug fixed related to Casbin.NET updated version 1.2.5.There were some implementation issue caused due to new Casbin.NET update those were fixed.  