### PR TITLE
Implemented async api for IAdapter interface at new version

### DIFF
--- a/EFCore-Adapter.UnitTest/TestUtil.cs
+++ b/EFCore-Adapter.UnitTest/TestUtil.cs
@@ -7,9 +7,8 @@ using NetCasbin;
 
 namespace EFCore_Adapter.Test
 {
-    public  class TestUtil
+    public class TestUtil
     {
-
         internal List<T> AsList<T>(params T[] values)
         {
             return values.ToList();

--- a/EFCore-Adapter/CasbinDbAdapter.cs
+++ b/EFCore-Adapter/CasbinDbAdapter.cs
@@ -24,9 +24,9 @@ namespace Casbin.NET.Adapter.EFCore
             LoadPolicyData(model, Helper.LoadPolicyLine, rules);
         }
 
-        public void RemovePolicy(string sec, string pType, IList<string> rule)
+        public void RemovePolicy(string sec, string ptype, IList<string> rule)
         {
-            RemoveFilteredPolicy(sec, pType, 0, rule.ToArray());
+            RemoveFilteredPolicy(sec, ptype, 0, rule.ToArray());
         }
 
         public void RemoveFilteredPolicy(string sec, string ptype, int fieldIndex, params string[] fieldValues)
@@ -99,33 +99,7 @@ namespace Casbin.NET.Adapter.EFCore
 
         public void SavePolicy(Model model)
         {
-            List<CasbinRule<TKey>> lines = new List<CasbinRule<TKey>>();
-            if (model.Model.ContainsKey("p"))
-            {
-                foreach (var kv in model.Model["p"])
-                {
-                    var ptype = kv.Key;
-                    var ast = kv.Value;
-                    foreach (var rule in ast.Policy)
-                    {
-                        var line = savePolicyLine(ptype, rule);
-                        lines.Add(line);
-                    }
-                }
-            }
-            if (model.Model.ContainsKey("g"))
-            {
-                foreach (var kv in model.Model["g"])
-                {
-                    var ptype = kv.Key;
-                    var ast = kv.Value;
-                    foreach (var rule in ast.Policy)
-                    {
-                        var line = savePolicyLine(ptype, rule);
-                        lines.Add(line);
-                    }
-                }
-            }
+            var lines = SavePolicyLines(model);
             if (lines.Any())
             {
                 _context.CasbinRule.AddRange(lines);
@@ -133,22 +107,45 @@ namespace Casbin.NET.Adapter.EFCore
             }
         }
 
-        public void AddPolicy(string sec, string pType, IList<string> rule)
+        public void AddPolicy(string sec, string ptype, IList<string> rule)
         {
-            var line = savePolicyLine(pType, rule);
+            var line = SavePolicyLine(ptype, rule);
             _context.CasbinRule.Add(line);
             _context.SaveChanges();
+        }
+
+        public async Task LoadPolicyAsync(Model model)
+        {
+            var rules = await _context.CasbinRule.ToListAsync();
+            LoadPolicyData(model, Helper.LoadPolicyLine, rules);
+        }
+
+        public async Task SavePolicyAsync(Model model)
+        {
+            var lines = SavePolicyLines(model);
+            if (lines.Any())
+            {
+                await _context.CasbinRule.AddRangeAsync(lines);
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task AddPolicyAsync(string sec, string ptype, IList<string> rule)
+        {
+            var line = SavePolicyLine(ptype, rule);
+            await _context.CasbinRule.AddAsync(line);
+            await _context.SaveChangesAsync();
         }
 
         private void LoadPolicyData(Model model, Helper.LoadPolicyLineHandler<string, Model> handler, IEnumerable<CasbinRule<TKey>> rules)
         {
             foreach (var rule in rules)
             {
-                handler(GetPolicyCotent(rule), model);
+                handler(GetPolicyContent(rule), model);
             }
         }
 
-        private string GetPolicyCotent(CasbinRule<TKey> rule)
+        private string GetPolicyContent(CasbinRule<TKey> rule)
         {
             StringBuilder sb = new StringBuilder(rule.PType);
             void Append(string v)
@@ -168,10 +165,10 @@ namespace Casbin.NET.Adapter.EFCore
             return sb.ToString();
         }
 
-        private CasbinRule<TKey> savePolicyLine(string pType, IList<string> rule)
+        private CasbinRule<TKey> SavePolicyLine(string ptype, IList<string> rule)
         {
             var line = new CasbinRule<TKey>();
-            line.PType = pType;
+            line.PType = ptype;
             if (rule.Count() > 0)
             {
                 line.V0 = rule[0];
@@ -200,19 +197,36 @@ namespace Casbin.NET.Adapter.EFCore
             return line;
         }
 
-        public Task LoadPolicyAsync(Model model)
+        private List<CasbinRule<TKey>> SavePolicyLines(Model model)
         {
-            throw new NotImplementedException();
-        }
-
-        public Task SavePolicyAsync(Model model)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task AddPolicyAsync(string sec, string ptype, IList<string> rule)
-        {
-            throw new NotImplementedException();
+            List<CasbinRule<TKey>> lines = new List<CasbinRule<TKey>>();
+            if (model.Model.ContainsKey("p"))
+            {
+                foreach (var kv in model.Model["p"])
+                {
+                    var ptype = kv.Key;
+                    var ast = kv.Value;
+                    foreach (var rule in ast.Policy)
+                    {
+                        var line = SavePolicyLine(ptype, rule);
+                        lines.Add(line);
+                    }
+                }
+            }
+            if (model.Model.ContainsKey("g"))
+            {
+                foreach (var kv in model.Model["g"])
+                {
+                    var ptype = kv.Key;
+                    var ast = kv.Value;
+                    foreach (var rule in ast.Policy)
+                    {
+                        var line = SavePolicyLine(ptype, rule);
+                        lines.Add(line);
+                    }
+                }
+            }
+            return lines;
         }
     }
 }


### PR DESCRIPTION
I was implemented async api for IAdapter interface at  the `Casbin.NET` new version, and I found it can not be test at now version. It looks will be used at `Casbin.NET` future versions.