### PR TITLE
Remove unnecessary packages and update refecence packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 mono: none
 solution: EFCore-Adapter.sln
 dist: xenial
-dotnet: 2.2
+dotnet: 3.1
 script:
     - dotnet restore
     - dotnet build

--- a/EFCore-Adapter.UnitTest/EFCore-Adapter.UnitTest.csproj
+++ b/EFCore-Adapter.UnitTest/EFCore-Adapter.UnitTest.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/EFCore-Adapter.UnitTest/EFCore-Adapter.UnitTest.csproj
+++ b/EFCore-Adapter.UnitTest/EFCore-Adapter.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>EFCore_Adapter.UnitTest</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/EFCore-Adapter/EFCore-Adapter.csproj
+++ b/EFCore-Adapter/EFCore-Adapter.csproj
@@ -4,16 +4,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Casbin.NET.Adapter.EFCore</RootNamespace>
     <PackageId>Casbin.NET.Adapter.EFCore</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Casbin.NET" Version="1.2.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Casbin.NET" Version="1.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I have changed the version from `1.2.0` to `1.2.1`, please review the changes.

There is the packages change list:
- Changed `Microsoft.EntityFrameworkCore.SqlServer` to `Microsoft.EntityFrameworkCore`
I think it only necessary the  `Microsoft.EntityFrameworkCore` package.
- Remove `Microsoft.EntityFrameworkCore.Desigin` package.
I think it only necessary at design-time and not at using. Whether it should be installed will be decided by user. 

Thanks for the reviews.