### PR TITLE
Added the ability to specify the default database schema name

### DIFF
--- a/Casbin.Adapter.EFCore/CasbinDbContext.cs
+++ b/Casbin.Adapter.EFCore/CasbinDbContext.cs
@@ -9,6 +9,7 @@ namespace Casbin.Adapter.EFCore
         public virtual DbSet<CasbinRule<TKey>> CasbinRule { get; set; }
 
         private readonly IEntityTypeConfiguration<CasbinRule<TKey>> _casbinModelConfig;
+        private readonly string _defaultSchemaName;
 
         public CasbinDbContext()
         {
@@ -19,13 +20,18 @@ namespace Casbin.Adapter.EFCore
             _casbinModelConfig = new DefaultCasbinRuleEntityTypeConfiguration<TKey>();
         }
 
-        public CasbinDbContext(DbContextOptions<CasbinDbContext<TKey>> options, IEntityTypeConfiguration<CasbinRule<TKey>> casbinModelConfig) : base(options)
+        public CasbinDbContext(DbContextOptions<CasbinDbContext<TKey>> options, IEntityTypeConfiguration<CasbinRule<TKey>> casbinModelConfig, string defaultSchemaName = "") : base(options)
         {
             _casbinModelConfig = casbinModelConfig;
+            _defaultSchemaName = defaultSchemaName;
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            if (!string.IsNullOrEmpty(_defaultSchemaName)) {
+                modelBuilder.HasDefaultSchema(_defaultSchemaName);
+            }
+
             if (_casbinModelConfig is not null)
             {
                 modelBuilder.ApplyConfiguration(_casbinModelConfig);


### PR DESCRIPTION
Added the ability to specify the default database schema name.

There was a need to use a non-standard database schema, added such a function. This change does not break backward compatibility.